### PR TITLE
新增支付返回类型集合 有助于在IDE中正确高亮

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 /vendor
 composer.lock
 .DS_Store
+.idea

--- a/src/WeChatOfficialAccountNoticeCollection.php
+++ b/src/WeChatOfficialAccountNoticeCollection.php
@@ -1,0 +1,26 @@
+<?php
+
+namespace Yansongda\Supports;
+
+/**
+ * @property-read string $appid 公众账号ID
+ * @property-read string $bank_type 付款银行
+ * @property-read int $cash_fee 现金支付金额
+ * @property-read string $fee_type 货币种类
+ * @property-read string $is_subscribe 是否关注公众账号
+ * @property-read string $mch_id 商户号
+ * @property-read string $nonce_str 随机字符串
+ * @property-read string $openid 用户标识
+ * @property-read string $out_trade_no 商户订单号
+ * @property-read string $result_code 业务结果
+ * @property-read string $return_code 返回状态码
+ * @property-read string $sign 签名
+ * @property-read string $time_end 支付完成时间
+ * @property-read int $total_fee 订单金额
+ * @property-read string $trade_type 交易类型
+ * @property-read string $transaction_id 微信支付订单号
+ * @mixin         Collection
+ */
+class WeChatOfficialAccountNoticeCollection
+{
+}

--- a/src/WeChatPayRefundCollection.php
+++ b/src/WeChatPayRefundCollection.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace Yansongda\Supports;
+
+/**
+ * @property-read string $out_refund_no 商户退款单号
+ * @property-read string $out_trade_no 商户订单号
+ * @property-read string $refund_account 退款资金来源
+ * @property-read int $refund_fee 申请退款金额(分)
+ * @property-read string $refund_id 微信退款单号
+ * @property-read string $refund_recv_accout 退款入账账户
+ * @property-read string $refund_request_source 退款发起来源
+ * @property-read string $refund_status 退款状态
+ * @property-read int $settlement_refund_fee 退款金额
+ * @property-read int $settlement_total_fee 应结订单金额
+ * @property-read string $success_time 退款成功时间
+ * @property-read int $total_fee 订单金额
+ * @property-read string $transaction_id 微信订单号
+ * @property-read string $return_code 返回状态码
+ * @property-read string $appid 公众账号ID
+ * @property-read string $mch_id 退款的商户号
+ * @property-read string $nonce_str 随机字符串
+ * @property-read string $req_info 加密信息
+ * @mixin         Collection
+ */
+class WeChatPayRefundCollection
+{
+}


### PR DESCRIPTION
新增支付返回类型集合 有助于在IDE中正确高亮。
数据结构取自 `公众号支付`
## 使用前
![image](https://user-images.githubusercontent.com/31845646/48247219-773dcc00-e42d-11e8-9973-4e16fcaf3354.png)

## 使用后
![image](https://user-images.githubusercontent.com/31845646/48247187-5f664800-e42d-11e8-8d2d-380348fa2730.png)

需要修改 `yansongda/pay` 中
- vendor/yansongda/pay/src/Gateways/Wechat.php:162 行
```doc
 @return Collection
```
修改后
```doc
@return WeChatPayRefundCollection|WeChatOfficialAccountNoticeCollection
```